### PR TITLE
Fixed Artifact __unicode__ now displays title if available.

### DIFF
--- a/wouso/core/magic/models.py
+++ b/wouso/core/magic/models.py
@@ -57,6 +57,8 @@ class Artifact(Modifier):
         return ArtifactGroup.objects.get_or_create(name='Default')[0]
 
     def __unicode__(self):
+        if self.title:
+            return u"%s" % self.title
         return u"%s [%s]" % (self.name, self.group.name)
 
 


### PR DESCRIPTION
Artifact **unicode** now displays title if available.

The only question I have is _when_ can an artifact _not_ have a title? Isn't the field mandatory?
