### PR TITLE
Fixed pagination bug

### DIFF
--- a/wouso/interface/apps/messaging/views.py
+++ b/wouso/interface/apps/messaging/views.py
@@ -29,7 +29,7 @@ def home(request, quiet=None, box=None):
 
     # working here
     messages  = messages.order_by('-timestamp')
-    paginator = Paginator(messages, 1)
+    paginator = Paginator(messages, 20)
     page = request.GET.get('page')
 
     try:


### PR DESCRIPTION
There was a bug in pagination. Thus, when switching tabs, the oldest messages were shown not the newest. This is because page request parameter was default set to 0. I think this happens in views.py when the parameter is returned 'page = request.GET.get('page')'  because page parameter was not set in the first GET request which made Django returned 0. Because paginator.page(1) returned the first page,  not paginator.page(0), paginator.page(0) returned EmptyPage, which executed the except code that showed the oldest messages. Now it shows the first messages. This may also mean that if the user gets over the messages length(trying to get the 999999999-th message) will return the first page. If this is not wanted there could be a fix like: 'if page ==0: paginator.page(1) else: paginator.page(paginator.num_pages)' .
