### PR TITLE
Fixed pagination bug

### DIFF
--- a/wouso/interface/apps/messaging/views.py
+++ b/wouso/interface/apps/messaging/views.py
@@ -37,7 +37,7 @@ def home(request, quiet=None, box=None):
     except PageNotAnInteger:
         # If page is not an integer, deliver first page.
         messages = paginator.page(1)
-    except EmptyPage: 
+    except EmptyPage:
         # If page is out of range (e.g. 9999), deliver last page of results.
         messages = paginator.page(paginator.num_pages)
 


### PR DESCRIPTION
There was a problem in that $.urlParam() returned 0 if there was no page param in the GET request. Django got the 0 parameter and because paginator.page(1) returns the first page, paginator.page(0) raised an EmptyPage exception which executed paginator.page(paginator.num_pages) delivering the oldest messages. So i changed the return 0 to return 1 in the javascript code.
