### PR TITLE
Fixed pagination bug

### DIFF
--- a/wouso/resources/static/js/tabs.js
+++ b/wouso/resources/static/js/tabs.js
@@ -29,17 +29,7 @@ function switchtab() {
     return false;
 }
 
-$.urlParam = function(name, url){
-    if(!url) {
-        url = window.location.href;
-    }
-    var results = new RegExp('[\\?&]' + name + '=([^&#]*)').exec(url);
-    if (!results) {
-        return 1;
-    }
 
-    return results[1] || 1;
-}
 
 /**
  * Executes when the user wants to load
@@ -62,7 +52,7 @@ function tabToURL(tab_name, url) {
     $("#" + tab_name).bind('custom',
         function() {
             $.ajax({
-                data: {'page':$.urlParam('page')},
+                data: {'page':1},
                 url: url,
                 success: function(data) {
                     $("#" + tab_name).html(data)


### PR DESCRIPTION
That function was unnecessary because it was called only when switching between tabs and when this happens, i think it would be normal to provide the user with the newest messages. Also, because when switching between tabs there was no page parameter in the GET request, the function returned 0, which in turn raised a EmptyPage exception on django(paginator.page(1) returns the first page, not paginator.page(0)) and in this way the oldest messages were returned to the user.
