### PR TITLE
Allow a privileged user to remove endorsement from a question

### DIFF
--- a/wouso/interface/cpanel/views.py
+++ b/wouso/interface/cpanel/views.py
@@ -420,19 +420,29 @@ def question_switch(request, id):
     # qproposal - endorse part
     proposed_cat = Category.objects.filter(name='proposed')[0]
     if question.category == proposed_cat:
+        player = question.proposed_by.get_profile()
+        staff_user = request.user
+        amount = 0
+        for tag in question.tags.all():
+            if tag.name == 'qotd':
+                amount = QOTD_GOLD
+            elif tag.name == 'challenge':
+                amount = CHALLENGE_GOLD
+            elif tag.name == 'quest':
+                amount = QUEST_GOLD
+
+        # Question is endorsed
         if not question.endorsed_by:
-            player = question.proposed_by.get_profile()
-            staff_user = request.user
             question.endorsed_by = staff_user
             question.save()
-            amount = 0
-            for tag in question.tags.all():
-                if tag.name == 'qotd':
-                    amount = QOTD_GOLD
-                elif tag.name == 'challenge':
-                    amount = CHALLENGE_GOLD
-                elif tag.name == 'quest':
-                    amount = QUEST_GOLD
+            scoring.score(player, None, 'bonus-gold', external_id=staff_user.id,
+                          gold=amount)
+
+        # Endorsement is removed from question
+        else:
+            question.endorsed_by = None
+            question.save()
+            amount *= -1
             scoring.score(player, None, 'bonus-gold', external_id=staff_user.id,
                           gold=amount)
 


### PR DESCRIPTION
Fix for: https://github.com/rosedu/wouso/issues/506

This is useful if a question is endorsed by mistake. Until now, an admin could not remove an endorsement from a question.
