### PR TITLE
Replace "CPanel" string with "Control Panel"

### DIFF
--- a/wouso/games/quest/templates/quest/cpanel_final_results.html
+++ b/wouso/games/quest/templates/quest/cpanel_final_results.html
@@ -2,7 +2,7 @@
 {% load user %}
 {% load django_bootstrap_breadcrumbs %}
 
-{% block title %}CPanel{% endblock %}
+{% block title %}Control Panel{% endblock %}
 {% block sectiontitle %}Final quest results{% endblock %}
 
 {% block breadcrumbs %}

--- a/wouso/games/quest/templates/quest/cpanel_quest_sort.html
+++ b/wouso/games/quest/templates/quest/cpanel_quest_sort.html
@@ -16,7 +16,7 @@ $(document).ready(function() {
 </script>
 {% endblock %}
 
-{% block title %}CPanel{% endblock %}
+{% block title %}Control Panel{% endblock %}
 
 {% block content %}
 

--- a/wouso/games/workshop/templates/workshop/index.html
+++ b/wouso/games/workshop/templates/workshop/index.html
@@ -58,7 +58,7 @@
 {% if perms.config.change_setting %}
 <h3>Staff only</h3>
 <p>
-    <a class="button" href="{% url ws_workshops %}">Go to CPanel</a>
+    <a class="button" href="{% url ws_workshops %}">Go to Control Panel</a>
 </p>
 {% endif %}
 {% endblock %}

--- a/wouso/resources/templates/admin/base_site.html
+++ b/wouso/resources/templates/admin/base_site.html
@@ -7,7 +7,7 @@
     <h1 id="site-name">{% trans 'Django administration' %}</h1>
     <a style="padding: 4px; min-width: 80px; margin-bottom: 10px; margin-right: 10px;
           background: #7CA0C7 url(../img/default-bg.gif) top left repeat-x;
-          display: inline-block; text-align: center; float: right;" href="{% url status %}">Back to CPanel</a>
+          display: inline-block; text-align: center; float: right;" href="{% url status %}">Back to Control Panel</a>
 {% endblock %}
 
 {% block nav-global %}{% endblock %}

--- a/wouso/resources/templates/cpanel/qpool_edit.html
+++ b/wouso/resources/templates/cpanel/qpool_edit.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load django_bootstrap_breadcrumbs %}
 
-{% block title %}CPanel{% endblock %}
+{% block title %}Control Panel{% endblock %}
 {% block sectiontitle %}{% if question %}Edit question #{{ question.id }}{% else %}New question{% endif %}{% endblock %}
 
 {% block breadcrumbs %}

--- a/wouso/resources/templates/cpanel/qpool_new.html
+++ b/wouso/resources/templates/cpanel/qpool_new.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load django_bootstrap_breadcrumbs %}
 
-{% block title %}CPanel{% endblock %}
+{% block title %}Control Panel{% endblock %}
 {% block sectiontitle %}Add question{% endblock %}
 {% block breadcrumbs %}
     {{ block.super }}

--- a/wouso/resources/templates/interface/header.html
+++ b/wouso/resources/templates/interface/header.html
@@ -9,7 +9,7 @@
             Impersonated by {{ user.real_user }} <a href="{% url impersonate_clear %}">clear</a>
         {% endif %}
         {% if perms.config.change_setting %}
-        <a id="head-cpanel" href="{% url status %}">CPanel</a>
+        <a id="head-cpanel" href="{% url status %}">Control Panel</a>
         {% endif %}
 
         <a id="head-logout" href="{% url logout_view %}" onclick="remove_storage()">{% trans "Logout" %} &raquo;</a>

--- a/wouso/resources/templates/mobile_base.html
+++ b/wouso/resources/templates/mobile_base.html
@@ -26,7 +26,7 @@
             {% player_simple player %}
             {% for h in heads %}<a href="{{ h.0.link }}">{{ h.0.text }}</a>{% endfor %}
             {% if user.is_staff %}
-            <a href="{% url status %}">CPanel</a>
+            <a href="{% url status %}">Control Panel</a>
             {% endif %}
             <a href="{% url logout_view %}">{% trans "Logout" %} &raquo;</a>
         {% else %}


### PR DESCRIPTION
Replace the "CPanel" string, mostly used in link names, with "Control Panel".
