### PR TITLE
templates: Fix inclusion of JavaScript scripts for adding/editing questions

### DIFF
--- a/wouso/resources/templates/cpanel/add_question.html
+++ b/wouso/resources/templates/cpanel/add_question.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block bottomscripts %}
-    <script type="text/javascript" src="{{ basepath }}/static/js/cpanel/qpool/add_question.js/"></script>
+    <script type="text/javascript" src="{{ basepath }}/static/js/cpanel/qpool/add_question.js"></script>
     <script src="{{ basepath }}/static/js/jquery-1.11.1.min.js"></script>
     <link rel="stylesheet" type="text/css" href="{{ basepath }}/static/css/cpanel-qpool.css" />
 

--- a/wouso/resources/templates/cpanel/edit_question.html
+++ b/wouso/resources/templates/cpanel/edit_question.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block bottomscripts %}
-    <script type="text/javascript" src="{{ basepath }}/static/js/cpanel/qpool/add_question.js/"></script>
+    <script type="text/javascript" src="{{ basepath }}/static/js/cpanel/qpool/add_question.js"></script>
     <script src="{{ basepath }}/static/js/jquery-1.11.1.min.js"></script>
     <link rel="stylesheet" type="text/css" href="{{ basepath }}/static/css/cpanel-qpool.css" />
     <script>


### PR DESCRIPTION
Due to slash at the end, the `static/js/cpanel/qpool/add_question.js` wasn't included in the page.