### PR TITLE
urls: Fix pagination URLs for quiz, lessons and files

### DIFF
--- a/wouso/games/quiz/cpanel_urls.py
+++ b/wouso/games/quiz/cpanel_urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('wouso.games.quiz.cpanel_views',
     url(r'^$', 'list_quizzes', name='list_quizzes'),
-    url(r'^/page(?P<page>[0-9]+)/$', 'list_quizzes', name='quizzes_page'),
+    url(r'^page/(?P<page>[0-9]+)/$', 'list_quizzes', name='quizzes_page'),
     url(r'^add_quiz/$', 'add_quiz', name='add_quiz'),
     url(r'^edit_quiz/(?P<pk>\d+)/$', 'edit_quiz', name='edit_quiz'),
     url(r'^delete_quiz/(?P<pk>\d+)/$', 'delete_quiz', name='delete_quiz'),

--- a/wouso/interface/apps/files/cpanel_urls.py
+++ b/wouso/interface/apps/files/cpanel_urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('wouso.interface.apps.files.cpanel_views',
     url(r'^$', 'files', name='files'),
-    url(r'^/page(?P<page>[0-9]+)/$', 'files', name='files_page'),
+    url(r'^page/(?P<page>[0-9]+)/$', 'files', name='files_page'),
     url(r'^add_file/$', 'add_file', name='add_file'),
     url(r'^edit_file/(?P<pk>\d+)/$', 'edit_file', name='edit_file'),
     url(r'^delete_file/(?P<pk>\d+)/$', 'delete_file', name='delete_file'),

--- a/wouso/interface/apps/lesson/cpanel_urls.py
+++ b/wouso/interface/apps/lesson/cpanel_urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, url
 
 urlpatterns = patterns('wouso.interface.apps.lesson.cpanel_views',
     url(r'^$', 'lessons', name='lessons'),
-    url(r'^/page(?P<page>[0-9]+)/$', 'lessons', name='lessons_page'),
+    url(r'^page/(?P<page>[0-9]+)/$', 'lessons', name='lessons_page'),
     url(r'^add_lesson/$', 'add_lesson', name='add_lesson'),
     url(r'^edit_lesson/(?P<id>\d+)/$', 'edit_lesson', name='edit_lesson'),
     url(r'^delete_lesson/(?P<pk>\d+)/$', 'delete_lesson', name='delete_lesson'),


### PR DESCRIPTION
There was a misplaced /  (slash) in the pagination URLs preventing them from working properly.