### PR TITLE
[TeamQuest] Update success messages for answering questions

### DIFF
--- a/wouso/games/teamquest/migrations/0002_auto__add_field_teamqueststatus_finish_position__add_field_teamquestle.py
+++ b/wouso/games/teamquest/migrations/0002_auto__add_field_teamqueststatus_finish_position__add_field_teamquestle.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'TeamQuestStatus.finish_position'
+        db.add_column('teamquest_teamqueststatus', 'finish_position',
+                      self.gf('django.db.models.fields.IntegerField')(default=-1),
+                      keep_default=False)
+
+        # Adding field 'TeamQuestLevelStatus.finish_position'
+        db.add_column('teamquest_teamquestlevelstatus', 'finish_position',
+                      self.gf('django.db.models.fields.IntegerField')(default=-1),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'TeamQuestStatus.finish_position'
+        db.delete_column('teamquest_teamqueststatus', 'finish_position')
+
+        # Deleting field 'TeamQuestLevelStatus.finish_position'
+        db.delete_column('teamquest_teamquestlevelstatus', 'finish_position')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'game.game': {
+            'Meta': {'object_name': 'Game'},
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'primary_key': 'True'}),
+            'short_name': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'url': ('django.db.models.fields.CharField', [], {'max_length': '64', 'blank': 'True'}),
+            'verbose_name': ('django.db.models.fields.CharField', [], {'max_length': '128', 'blank': 'True'})
+        },
+        'magic.artifact': {
+            'Meta': {'unique_together': "(('name', 'group', 'percents'),)", 'object_name': 'Artifact'},
+            'description': ('django.db.models.fields.TextField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['magic.ArtifactGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'percents': ('django.db.models.fields.IntegerField', [], {'default': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'magic.artifactgroup': {
+            'Meta': {'object_name': 'ArtifactGroup'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'magic.groupartifactamount': {
+            'Meta': {'unique_together': "(('group', 'artifact'),)", 'object_name': 'GroupArtifactAmount'},
+            'amount': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'artifact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['magic.Artifact']"}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['user.PlayerGroup']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'magic.playerartifactamount': {
+            'Meta': {'unique_together': "(('player', 'artifact'),)", 'object_name': 'PlayerArtifactAmount'},
+            'amount': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'artifact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['magic.Artifact']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'player': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['user.Player']"})
+        },
+        'magic.playerspellamount': {
+            'Meta': {'unique_together': "(('player', 'spell'),)", 'object_name': 'PlayerSpellAmount'},
+            'amount': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'player': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['user.Player']"}),
+            'spell': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['magic.Spell']"})
+        },
+        'magic.raceartifactamount': {
+            'Meta': {'unique_together': "(('race', 'artifact'),)", 'object_name': 'RaceArtifactAmount'},
+            'amount': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'artifact': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['magic.Artifact']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'race': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['user.Race']"})
+        },
+        'magic.spell': {
+            'Meta': {'object_name': 'Spell'},
+            'available': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'max_length': '2000', 'null': 'True', 'blank': 'True'}),
+            'due_days': ('django.db.models.fields.IntegerField', [], {'default': '5'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'level_required': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'mass': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'percents': ('django.db.models.fields.IntegerField', [], {'default': '100'}),
+            'price': ('django.db.models.fields.FloatField', [], {'default': '10'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'o'", 'max_length': '1'})
+        },
+        'qpool.category': {
+            'Meta': {'object_name': 'Category'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'qpool.question': {
+            'Meta': {'object_name': 'Question'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'answer_type': ('django.db.models.fields.CharField', [], {'default': "'C'", 'max_length': '1'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['qpool.Category']", 'null': 'True'}),
+            'code': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'date_added': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_changed': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'endorsed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'qpool_question_endorsedby_related'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'proposed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'qpool_question_proposedby_related'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'rich_text': ('ckeditor.fields.RichTextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'tags': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['qpool.Tag']", 'symmetrical': 'False', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {'default': "''", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'S'", 'max_length': '1'})
+        },
+        'qpool.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['qpool.Category']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '256'})
+        },
+        'teamquest.teamquest': {
+            'Meta': {'object_name': 'TeamQuest'},
+            'end_time': ('django.db.models.fields.DateTimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'start_time': ('django.db.models.fields.DateTimeField', [], {}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100'})
+        },
+        'teamquest.teamquestgroup': {
+            'Meta': {'object_name': 'TeamQuestGroup', '_ormbases': ['user.PlayerGroup']},
+            'group_owner': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['teamquest.TeamQuestUser']", 'unique': 'True', 'null': 'True'}),
+            'playergroup_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['user.PlayerGroup']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'teamquest.teamquestinvitation': {
+            'Meta': {'object_name': 'TeamQuestInvitation'},
+            'from_group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamquest.TeamQuestGroup']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamquest.TeamQuestUser']", 'null': 'True'})
+        },
+        'teamquest.teamquestinvitationrequest': {
+            'Meta': {'object_name': 'TeamQuestInvitationRequest'},
+            'from_user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamquest.TeamQuestUser']", 'null': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'to_group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamquest.TeamQuestGroup']", 'null': 'True'})
+        },
+        'teamquest.teamquestlevel': {
+            'Meta': {'object_name': 'TeamQuestLevel'},
+            'bonus': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'quest': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'levels'", 'null': 'True', 'to': "orm['teamquest.TeamQuest']"}),
+            'questions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['qpool.Question']", 'symmetrical': 'False'})
+        },
+        'teamquest.teamquestlevelstatus': {
+            'Meta': {'object_name': 'TeamQuestLevelStatus'},
+            'finish_position': ('django.db.models.fields.IntegerField', [], {'default': '-1'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'actives'", 'to': "orm['teamquest.TeamQuestLevel']"}),
+            'quest_status': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'levels'", 'to': "orm['teamquest.TeamQuestStatus']"})
+        },
+        'teamquest.teamquestquestion': {
+            'Meta': {'object_name': 'TeamQuestQuestion'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'level': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'questions'", 'null': 'True', 'to': "orm['teamquest.TeamQuestLevelStatus']"}),
+            'lock': ('django.db.models.fields.CharField', [], {'default': "'L'", 'max_length': '1'}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['qpool.Question']", 'null': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'default': "'U'", 'max_length': '1'})
+        },
+        'teamquest.teamqueststatus': {
+            'Meta': {'object_name': 'TeamQuestStatus'},
+            'finish_position': ('django.db.models.fields.IntegerField', [], {'default': '-1'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamquest.TeamQuestGroup']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'quest': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamquest.TeamQuest']"}),
+            'time_finished': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'time_started': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2015, 5, 6, 0, 0)'})
+        },
+        'teamquest.teamquestuser': {
+            'Meta': {'object_name': 'TeamQuestUser', '_ormbases': ['user.Player']},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'related_name': "'users'", 'null': 'True', 'blank': 'True', 'to': "orm['teamquest.TeamQuestGroup']"}),
+            'player_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['user.Player']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        'user.player': {
+            'Meta': {'object_name': 'Player'},
+            'artifacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['magic.Artifact']", 'symmetrical': 'False', 'through': "orm['magic.PlayerArtifactAmount']", 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'max_length': '600', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_seen': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'level_no': ('django.db.models.fields.IntegerField', [], {'default': '1', 'null': 'True', 'blank': 'True'}),
+            'max_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'nickname': ('django.db.models.fields.CharField', [], {'default': "'admin'", 'max_length': '20', 'null': 'True'}),
+            'points': ('django.db.models.fields.FloatField', [], {'default': '0', 'null': 'True', 'blank': 'True'}),
+            'race': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['user.Race']", 'null': 'True'}),
+            'spells_collection': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'spell_collection'", 'blank': 'True', 'through': "orm['magic.PlayerSpellAmount']", 'to': "orm['magic.Spell']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'player_related'", 'unique': 'True', 'to': "orm['auth.User']"})
+        },
+        'user.playergroup': {
+            'Meta': {'object_name': 'PlayerGroup'},
+            'artifacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['magic.Artifact']", 'symmetrical': 'False', 'through': "orm['magic.GroupArtifactAmount']", 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['game.Game']", 'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': "orm['user.Race']", 'null': 'True', 'blank': 'True'}),
+            'players': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['user.Player']", 'symmetrical': 'False', 'blank': 'True'}),
+            'points': ('django.db.models.fields.FloatField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'blank': 'True'})
+        },
+        'user.race': {
+            'Meta': {'object_name': 'Race'},
+            'artifacts': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['magic.Artifact']", 'symmetrical': 'False', 'through': "orm['magic.RaceArtifactAmount']", 'blank': 'True'}),
+            'can_play': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'logo': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'title': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['teamquest']

--- a/wouso/games/teamquest/models.py
+++ b/wouso/games/teamquest/models.py
@@ -308,6 +308,19 @@ class TeamQuestStatus(models.Model):
             points += questions.count() * level.points_per_question
         return points
 
+    @property
+    def time_taken(self):
+        time_taken = ""
+        if self.time_finished is None:
+            return time_taken
+        interval = self.time_finished - self.time_started
+        if interval.days:
+            time_taken += str(interval.days) + " day(s) "
+        if interval.seconds:
+            time_taken += str(interval.seconds / 3600) + " hour(s) "
+            time_taken += str(interval.seconds % 3600 / 60) + " minute(s)"
+        return time_taken
+
     def __unicode__(self):
         return u"%s [%s]" % (self.quest.title, self.group.name)
 

--- a/wouso/games/teamquest/templates/teamquest/index.html
+++ b/wouso/games/teamquest/templates/teamquest/index.html
@@ -61,7 +61,7 @@
                             </div>
                         </form>
                         {% else %}
-                            <p>{% trans 'You have answered this question.' %}</p>
+                            <p>{% blocktrans with points=l.level.points_per_question %} You have answered this question and received {{ points }} experience points. {% endblocktrans %}</p>
                         {% endif %}
                     {% endfor %}
                     </div>

--- a/wouso/games/teamquest/templates/teamquest/index.html
+++ b/wouso/games/teamquest/templates/teamquest/index.html
@@ -17,61 +17,60 @@
 {% elif not group %}
     <p>{% trans 'You need a group to participate in this quest.' %}</p>
 {% else %}
-    {% if status.progress < quest.total_points %}
+    {% if status.progress == quest.total_points %}
+        <p>{% blocktrans with position=status.finish_position time_taken=status.time_taken %} You have finished this quest on position #{{ position }} and it took you {{ time_taken}}. {% endblocktrans %}</p>
+    {% else %}
         <br>
         <h3>
         <p>{% blocktrans with title=quest.title %} You are now adventuring in quest "{{ title }}". {% endblocktrans %}</p>
         <p>{% blocktrans with name=group.name progress=status.progress %} Your steadfast group {{name }} have aquired {{ progress }} experience points. {% endblocktrans %}</p>
         </h3>
-        <br>
-
-        <ul class="tabs">
-        {% for l in levels %}
-            {% if l.unlocked_questions.count %}
-                 <li>
-                    <a href="#level{{ l.level.index }}" id="level{{ l.level.index }}-click" class="no-redir">
-                        {% blocktrans with index=l.level.roman_index %} Stage {{ index }} {% endblocktrans %}
-                    </a>
-                </li>
-            {% endif %}
-        {% endfor %}
-        </ul>
-
-        <div class="tab_container">
-        {% for l in levels %}
-            {% if l.unlocked_questions.count %}
-                {% if l.completed %}
-                    <div id="level{{ l.level.index }}" class="tab_content">
-                        <br>
-                        <p> {% trans 'You have completed this level. Spot on!' %} </p>
-                    </div>
-                {% else %}
-                    <div id="level{{ l.level.index }}" class="tab_content">
-                    {% for q in l.unlocked_questions.all %}
-                        <br>
-                        <h3> {{ q.question.text }}  </h3>
-                        {% if q.state == 'U' %}
-                        <form method="post" action="{% url teamquest_index_view %}" id="{{ q.index }}">
-                            {% csrf_token %}
-                            <table>
-                                <input type="text" name="form{{ q.index }}">
-                            </table>
-                            <div class="actions">
-                                <button type="submit" class="default">{% trans 'Answer' %}</button>
-                            </div>
-                        </form>
-                        {% else %}
-                            <p>{% blocktrans with points=l.level.points_per_question %} You have answered this question and received {{ points }} experience points. {% endblocktrans %}</p>
-                        {% endif %}
-                    {% endfor %}
-                    </div>
-                {% endif %} 
-            {% endif %}
-        {% endfor %}
-        </div>
-    {% else %}
-        <p>{% trans 'You have finished this quest.' %}</p>
     {% endif %}
+    <br>
+
+    <ul class="tabs">
+    {% for l in levels %}
+        {% if l.unlocked_questions.count %}
+             <li>
+                <a href="#level{{ l.level.index }}" id="level{{ l.level.index }}-click" class="no-redir">
+                    {% blocktrans with index=l.level.roman_index %} Stage {{ index }} {% endblocktrans %}
+                </a>
+            </li>
+        {% endif %}
+    {% endfor %}
+    </ul>
+
+    <div class="tab_container">
+    {% for l in levels %}
+        {% if l.unlocked_questions.count %}
+            <div id="level{{ l.level.index }}" class="tab_content">
+            <br>
+            <p>{% blocktrans with points=l.progress %} You have obtained {{ points }} points on this level. {% endblocktrans %}</p>
+            {% if l.completed %}
+                <p>{%blocktrans with position=l.finish_position %} You have completed this level on position #{{ position }}. Spot on! {% endblocktrans %} </p>
+            {% else %}
+                {% for q in l.unlocked_questions.all %}
+                    <br>
+                    <h3> {{ q.question.text }}  </h3>
+                    {% if q.state == 'U' %}
+                    <form method="post" action="{% url teamquest_index_view %}" id="{{ q.index }}">
+                        {% csrf_token %}
+                        <table>
+                            <input type="text" name="form{{ q.index }}">
+                        </table>
+                        <div class="actions">
+                            <button type="submit" class="default">{% trans 'Answer' %}</button>
+                        </div>
+                    </form>
+                    {% else %}
+                        <p>{% blocktrans with points=l.level.points_per_question %} You have answered this question and received {{ points }} experience points. {% endblocktrans %}</p>
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+            </div>
+        {% endif %}
+    {% endfor %}
+    </div>
 {% endif %}
 
 {% endblock %}

--- a/wouso/games/teamquest/templates/teamquest/index.html
+++ b/wouso/games/teamquest/templates/teamquest/index.html
@@ -18,12 +18,24 @@
     <p>{% trans 'You need a group to participate in this quest.' %}</p>
 {% else %}
     {% if status.progress == quest.total_points %}
-        <p>{% blocktrans with position=status.finish_position time_taken=status.time_taken %} You have finished this quest on position #{{ position }} and it took you {{ time_taken}}. {% endblocktrans %}</p>
+        <p>
+        {% blocktrans with position=status.finish_position time_taken=status.time_taken %}
+            You have finished this quest on position #{{ position }} and it took you {{ time_taken}}.
+        {% endblocktrans %}
+        </p>
     {% else %}
         <br>
         <h3>
-        <p>{% blocktrans with title=quest.title %} You are now adventuring in quest "{{ title }}". {% endblocktrans %}</p>
-        <p>{% blocktrans with name=group.name progress=status.progress %} Your steadfast group {{name }} have aquired {{ progress }} experience points. {% endblocktrans %}</p>
+        <p>
+        {% blocktrans with title=quest.title %}
+            You are now adventuring in quest "{{ title }}".
+        {% endblocktrans %}
+        </p>
+        <p>
+        {% blocktrans with name=group.name progress=status.progress %}
+            Your steadfast group {{name }} have aquired {{ progress }} experience points.
+        {% endblocktrans %}
+        </p>
         </h3>
     {% endif %}
     <br>
@@ -45,9 +57,17 @@
         {% if l.unlocked_questions.count %}
             <div id="level{{ l.level.index }}" class="tab_content">
             <br>
-            <p>{% blocktrans with points=l.progress %} You have obtained {{ points }} points on this level. {% endblocktrans %}</p>
+            <p>
+            {% blocktrans with points=l.progress %}
+                You have obtained {{ points }} points on this level.
+            {% endblocktrans %}
+            </p>
             {% if l.completed %}
-                <p>{%blocktrans with position=l.finish_position %} You have completed this level on position #{{ position }}. Spot on! {% endblocktrans %} </p>
+                <p>
+                {%blocktrans with position=l.finish_position %}
+                    You have completed this level on position #{{ position }}. Spot on!
+                {% endblocktrans %}
+                </p>
             {% else %}
                 {% for q in l.unlocked_questions.all %}
                     <br>
@@ -63,7 +83,11 @@
                         </div>
                     </form>
                     {% else %}
-                        <p>{% blocktrans with points=l.level.points_per_question %} You have answered this question and received {{ points }} experience points. {% endblocktrans %}</p>
+                        <p>
+                        {% blocktrans with points=l.level.points_per_question %}
+                            You have answered this question and received {{ points }} experience points.
+                        {% endblocktrans %}
+                        </p>
                     {% endif %}
                 {% endfor %}
             {% endif %}

--- a/wouso/games/teamquest/tests.py
+++ b/wouso/games/teamquest/tests.py
@@ -343,6 +343,53 @@ class TeamQuestStatusTest(TestCase):
 
         self.assertEqual(level_status2.level.times_completed, 2)
 
+    def test_level_finish_position_default(self):
+        status = TeamQuestStatus.create(group=self.group, quest=self.quest)
+
+        for level_status in status.levels.all():
+            self.assertEqual(level_status.finish_position, -1)
+
+
+    def test_level_status_finish_incorrect(self):
+        status = TeamQuestStatus.create(group=self.group, quest=self.quest)
+
+        for level_status in status.levels.all():
+            level_status.finish()
+
+        for level_status in status.levels.all():
+            self.assertEqual(level_status.finish_position, -1)
+
+    def test_level_status_finish_correct(self):
+        status = TeamQuestStatus.create(group=self.group, quest=self.quest)
+
+        for level_status in status.levels.all():
+            for question in level_status.questions.all():
+                question.state = 'A'
+                question.save()
+            level_status.finish()
+
+        for level_status in status.levels.all():
+            self.assertEqual(level_status.finish_position, 1)
+
+    def test_quest_status_finish_position_default(self):
+        status = TeamQuestStatus.create(group=self.group, quest=self.quest)
+
+        self.assertEqual(status.finish_position, -1)
+
+    def test_quest_status_finish_position(self):
+        status = TeamQuestStatus.create(group=self.group, quest=self.quest)
+
+        for level_status in status.levels.all():
+            for question in level_status.questions.all():
+                question.state = 'A'
+                question.save()
+            level_status.finish()
+        status = TeamQuestStatus.objects.get(group=self.group, quest=self.quest)
+
+        self.assertEqual(status.finish_position, 1)
+        print status.time_taken
+        self.assertEqual(1, 2)
+
     def test_quest_status_time_finished_before_time_started(self):
         pass
 

--- a/wouso/games/teamquest/tests.py
+++ b/wouso/games/teamquest/tests.py
@@ -349,7 +349,6 @@ class TeamQuestStatusTest(TestCase):
         for level_status in status.levels.all():
             self.assertEqual(level_status.finish_position, -1)
 
-
     def test_level_status_finish_incorrect(self):
         status = TeamQuestStatus.create(group=self.group, quest=self.quest)
 
@@ -387,8 +386,6 @@ class TeamQuestStatusTest(TestCase):
         status = TeamQuestStatus.objects.get(group=self.group, quest=self.quest)
 
         self.assertEqual(status.finish_position, 1)
-        print status.time_taken
-        self.assertEqual(1, 2)
 
     def test_quest_status_time_finished_before_time_started(self):
         pass

--- a/wouso/games/teamquest/views.py
+++ b/wouso/games/teamquest/views.py
@@ -59,18 +59,18 @@ class TeamQuestIndexView(ListView):
                 quest_user.score(amount=level.level.points_per_question)
 
                 if question.level.questions.all().count() == 1:
-                    messages.success(request, _('Congratulations! You have completed this quest on position #%(tc)d!') % {'tc': level.level.times_completed})
-                    if level.level.bonus and level.level.times_completed == 1:
+                    level.finish()
+                    messages.success(request, _('Congratulations! You have completed this quest on position #%(fp)d!') % {'fp': level.finish_position})
+                    if level.level.bonus and level.finish_position == 1:
                         messages.success(request, _('For being the first to complete this quest, your team is awarded %(lb)d experience points.') % {'lb': level.level.bonus})
                         quest_user.score(amount=level.level.bonus)
-
-                    status.finish()
 
                 else:
 
                     if level.completed:
-                        messages.success(request, _('Congratulations! You have completed this level on position #%(tc)d!') % {'tc': level.level.times_completed})
-                        if level.level.bonus and level.level.times_completed == 1:
+                        level.finish()
+                        messages.success(request, _('Congratulations! You have completed this level on position #%(fp)d!') % {'fp': level.finish_position})
+                        if level.level.bonus and level.finish_position == 1:
                             messages.success(request, _('For being the first to complete this level, your team is awarded %(lb)d experience points.') % {'lb': level.level.bonus})
                             quest_user.score(amount=level.level.bonus)
 

--- a/wouso/games/teamquest/views.py
+++ b/wouso/games/teamquest/views.py
@@ -59,9 +59,9 @@ class TeamQuestIndexView(ListView):
                 quest_user.score(amount=level.level.points_per_question)
 
                 if question.level.questions.all().count() == 1:
-                    messages.success(request, _('Congratulations! You have finished this quest on position #%(tc)d!') % {'tc': level.level.times_completed})
-                    if level.level.times_completed == 1:
-                        messages.success(request, _('For being the first to complete this quest, your team is awarded %(tc)d points.') % {'tc': level.level.bonus})
+                    messages.success(request, _('Congratulations! You have completed this quest on position #%(tc)d!') % {'tc': level.level.times_completed})
+                    if level.level.bonus and level.level.times_completed == 1:
+                        messages.success(request, _('For being the first to complete this quest, your team is awarded %(lb)d experience points.') % {'lb': level.level.bonus})
                         quest_user.score(amount=level.level.bonus)
 
                     status.finish()
@@ -69,16 +69,15 @@ class TeamQuestIndexView(ListView):
                 else:
 
                     if level.completed:
-                        messages.success(request, _('Congratulations! You have finished this level on position #%(tc)d!') % {'tc': level.level.times_completed})
-                        if level.level.times_completed == 1:
-                            messages.success(request, _('For being the first to complete this level, your team is awarded %(tc)d points.') % {'tc': level.level.bonus})
+                        messages.success(request, _('Congratulations! You have completed this level on position #%(tc)d!') % {'tc': level.level.times_completed})
+                        if level.level.bonus and level.level.times_completed == 1:
+                            messages.success(request, _('For being the first to complete this level, your team is awarded %(lb)d experience points.') % {'lb': level.level.bonus})
                             quest_user.score(amount=level.level.bonus)
 
                     other_questions = TeamQuestQuestion.objects.filter(level=question.level, state='A')
+                    messages.success(request, _('Correct answer! Your team is awarded %(pt)d experience  points.') % {'pt': level.level.points_per_question})
                     if other_questions.count() > 1:
-                        messages.success(request, _('Correct answer! You unlocked a question on Level %(nl)d!') % {'nl': level.next_level.level.index})
-                    else:
-                        messages.success(request, _('Correct answer!'))
+                        messages.success(request, _('You unlocked a question on Level %(in)d!') % {'in': level.next_level.level.index})
 
                 return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 

--- a/wouso/games/teamquest/views.py
+++ b/wouso/games/teamquest/views.py
@@ -60,24 +60,36 @@ class TeamQuestIndexView(ListView):
 
                 if question.level.questions.all().count() == 1:
                     level.finish()
-                    messages.success(request, _('Congratulations! You have completed this quest on position #%(fp)d!') % {'fp': level.finish_position})
+                    messages.success(request,
+                        _('Congratulations! You have completed this quest on position #%(fp)d!')
+                        % {'fp': level.finish_position})
                     if level.level.bonus and level.finish_position == 1:
-                        messages.success(request, _('For being the first to complete this quest, your team is awarded %(lb)d experience points.') % {'lb': level.level.bonus})
+                        messages.success(request,
+                            _('For being the first to complete this quest, your team is awarded %(lb)d experience points.')
+                            % {'lb': level.level.bonus})
                         quest_user.score(amount=level.level.bonus)
 
                 else:
 
                     if level.completed:
                         level.finish()
-                        messages.success(request, _('Congratulations! You have completed this level on position #%(fp)d!') % {'fp': level.finish_position})
+                        messages.success(request,
+                            _('Congratulations! You have completed this level on position #%(fp)d!')
+                            % {'fp': level.finish_position})
                         if level.level.bonus and level.finish_position == 1:
-                            messages.success(request, _('For being the first to complete this level, your team is awarded %(lb)d experience points.') % {'lb': level.level.bonus})
+                            messages.success(request,
+                                _('For being the first to complete this level, your team is awarded %(lb)d experience points.')
+                                % {'lb': level.level.bonus})
                             quest_user.score(amount=level.level.bonus)
 
                     other_questions = TeamQuestQuestion.objects.filter(level=question.level, state='A')
-                    messages.success(request, _('Correct answer! Your team is awarded %(pt)d experience  points.') % {'pt': level.level.points_per_question})
+                    messages.success(request,
+                        _('Correct answer! Your team is awarded %(pt)d experience  points.')
+                        % {'pt': level.level.points_per_question})
                     if other_questions.count() > 1:
-                        messages.success(request, _('You unlocked a question on Level %(in)d!') % {'in': level.next_level.level.index})
+                        messages.success(request,
+                            _('You unlocked a question on Level %(in)d!')
+                            % {'in': level.next_level.level.index})
 
                 return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 


### PR DESCRIPTION
Fix #727, #728, #729, #730, #731.
@razvand 
@iulianR

I added the possibilities to:
- see the points accumulated in every unlocked level, even after finishing it
- see on what position a level was finished by your team
- see on what position the quest was finished by your team and how long it took