### PR TITLE
Rework challenge winning percentage

### DIFF
--- a/wouso/games/challenge/models.py
+++ b/wouso/games/challenge/models.py
@@ -22,6 +22,7 @@ import logging
 class ChallengeException(Exception):
     pass
 
+
 class ChallengeUser(Player):
     """ Extension of the userprofile, customized for challenge """
 
@@ -55,7 +56,7 @@ class ChallengeUser(Player):
         from wouso.interface.top.models import TopUser
         position_diff = abs(self.get_extension(TopUser).position - user.get_extension(TopUser).position)
         if position_diff <= 20:
-          return True
+            return True
         return False
 
     def can_challenge(self, user):
@@ -83,11 +84,11 @@ class ChallengeUser(Player):
         self.save()
 
         signal_msg = ugettext_noop('used {artifact} to enable one more challenge.')
-        signals.addActivity.send(sender=None, user_from=self, \
-                                     user_to=self, \
-                                     message=signal_msg, \
-                                     arguments=dict(artifact=modifier.artifact.title), \
-                                     game=ChallengeGame.get_instance())
+        signals.addActivity.send(sender=None, user_from=self,
+                                 user_to=self,
+                                 message=signal_msg,
+                                 arguments=dict(artifact=modifier.artifact.title),
+                                 game=ChallengeGame.get_instance())
         return True
 
     def can_play(self, challenge):
@@ -111,7 +112,7 @@ class ChallengeUser(Player):
         return Challenge.create(user_from=self, user_to=destination)
 
     def set_last_launched(self, value):
-        logging.info("set last launched of %s to %s" %(hex(id(self)), value))
+        logging.info("set last launched of %s to %s" % (hex(id(self)), value))
         self.last_launched = value
         self.save()
 
@@ -151,9 +152,9 @@ class ChallengeUser(Player):
     def get_related_challenges(self, target_user):
         # Gets the challenges between self and target_user
         chall_total = Challenge.objects.filter(Q(user_from__user=self) |
-                Q(user_to__user=self)).exclude(status=u'L')
+                                               Q(user_to__user=self)).exclude(status=u'L')
         chall_total = chall_total.filter(Q(user_from__user=target_user) |
-                Q(user_to__user=target_user)).order_by('-date')
+                                         Q(user_to__user=target_user)).order_by('-date')
         return chall_total
 
     def get_stats(self):
@@ -169,14 +170,13 @@ class ChallengeUser(Player):
         n_chall_ref = self.get_refused_challenges().count()
         all_participation = Participant.objects.filter(user=self)
 
-        opponents_from = list(set(map(lambda x : x.user_to.user, chall_sent)))
-        opponents_to = list(set(map(lambda x : x.user_from.user, chall_rec)))
+        opponents_from = list(set(map(lambda x: x.user_to.user, chall_sent)))
+        opponents_to = list(set(map(lambda x: x.user_from.user, chall_rec)))
         opponents = list(set(opponents_from + opponents_to))
 
         result = []
         for op in opponents:
-            chall_against_op = chall_total.filter(Q(user_to__user=op) |
-                    Q(user_from__user=op))
+            chall_against_op = chall_total.filter(Q(user_to__user=op) | Q(user_from__user=op))
             won = chall_against_op.filter(Q(status=u'P') & Q(winner=self)).count()
             lost = chall_against_op.filter(Q(status=u'P') & Q(winner=op)).count()
             draw = chall_against_op.filter(Q(status=u'D')).count()
@@ -190,8 +190,10 @@ class ChallengeUser(Player):
         average_time = all_participation.aggregate(Avg('seconds_took'))['seconds_took__avg']
         average_score = all_participation.aggregate(Avg('score'))['score__avg']
 
-        if average_time == None : average_time = 0
-        if average_score == None : average_score = 0
+        if average_time is None:
+            average_time = 0
+        if average_score is None:
+            average_score = 0
 
         win_percentage = self.get_win_percentage()
 
@@ -204,24 +206,26 @@ class ChallengeUser(Player):
 
 Player.register_extension('challenge', ChallengeUser)
 
+
 class Participant(models.Model):
     user = models.ForeignKey(ChallengeUser)
     start = models.DateTimeField(null=True, blank=True)
     seconds_took = models.IntegerField(null=True, blank=True)
     played = models.BooleanField(default=False)
     responses = models.TextField(default='', blank=True, null=True)
-    #score = models.FloatField(null=True, blank=True)
+    # score = models.FloatField(null=True, blank=True)
     score = models.IntegerField(null=True, blank=True)
 
     @property
     def challenge(self):
         try:
-            return Challenge.objects.get(Q(user_from=self)|Q(user_to=self))
+            return Challenge.objects.get(Q(user_from=self) | Q(user_to=self))
         except Challenge.DoesNotExist:
             return None
 
     def __unicode__(self):
         return unicode(self.user)
+
 
 class Challenge(models.Model):
     STATUS = (
@@ -241,13 +245,13 @@ class Challenge(models.Model):
 
     nr_q = 0
     LIMIT = 5
-    TIME_LIMIT = 300 # seconds
-    TIME_SAFE = 10 # seconds more
-    WARRANTY = True # on/off switch
-    SCORING = True # on/off switch for rewarding challenges
+    TIME_LIMIT = 300  # seconds
+    TIME_SAFE = 10    # seconds more
+    WARRANTY = True   # on/off switch
+    SCORING = True    # on/off switch for rewarding challenges
 
     @classmethod
-    def create(cls, user_from, user_to, ignore_questions = False):
+    def create(cls, user_from, user_to, ignore_questions=False):
         """ Assigns questions, and returns the number of assigned q """
         questions = [q for q in get_questions_with_category('challenge')]
         if (len(questions) < cls.LIMIT) and not ignore_questions:
@@ -281,7 +285,7 @@ class Challenge(models.Model):
         Return all expired candidate challenges at given date.
         """
         yesterday = today + timedelta(days=-1)
-        return Challenge.objects.filter(date__lt=yesterday).filter(Q(status='A')|Q(status='L'))
+        return Challenge.objects.filter(date__lt=yesterday).filter(Q(status='A') | Q(status='L'))
 
     @classmethod
     def exist_last_day(cls, today, user_from, user_to):
@@ -373,8 +377,7 @@ class Challenge(models.Model):
         now = datetime.now()
         partic = self.participant_for_player(user)
 
-        tlimit=scoring.timer(user, ChallengeGame, 'chall-timer',
-                level=user.level_no)
+        tlimit = scoring.timer(user, ChallengeGame, 'chall-timer', level=user.level_no)
 
         return tlimit - (now - partic.start).seconds
 
@@ -425,7 +428,7 @@ class Challenge(models.Model):
             return _('(in {time})').format(time=ret)
 
         return '%dp %s - %dp %s' % (user_won.score, formatTime(user_won.seconds_took),
-                                        user_lost.score, formatTime(user_lost.seconds_took))
+                                    user_lost.score, formatTime(user_lost.seconds_took))
 
     def played(self):
         """ Both players have played, save and score
@@ -473,8 +476,8 @@ class Challenge(models.Model):
                 qpoints = float(checked) / correct_count - float(wrong) / wrong_count
             qpoints = qpoints if qpoints > 0 else 0
             points += qpoints
-            results[r] = (( checked, correct_count ))
-        return {'points': int(100.0 * points), 'results' : results}
+            results[r] = ((checked, correct_count))
+        return {'points': int(100.0 * points), 'results': results}
 
     def set_played(self, user, responses):
         """ Set user's results. If both users have played, also update self and activity. """
@@ -567,6 +570,7 @@ class ChallengeManager(object):
     def score(self):
         raise NotImplementedError
 
+
 class DefaultChallengeManager(ChallengeManager):
     def created(self):
         if self.challenge.WARRANTY:
@@ -587,12 +591,13 @@ class DefaultChallengeManager(ChallengeManager):
         else:
             signal_msg = ugettext_noop('has refused challenge from {chall_from}')
         action_msg = 'chall-refused'
-        signals.addActivity.send(sender=None, user_from=self.challenge.user_to.user, \
-                                     user_to=self.challenge.user_from.user, \
-                                     message=signal_msg, \
-                                     arguments=dict(chall_from=self.challenge.user_from), \
-                                     action=action_msg, \
-                                     game=ChallengeGame.get_instance())
+        signals.addActivity.send(sender=None,
+                                 user_from=self.challenge.user_to.user,
+                                 user_to=self.challenge.user_from.user,
+                                 message=signal_msg,
+                                 arguments=dict(chall_from=self.challenge.user_from),
+                                 action=action_msg,
+                                 game=ChallengeGame.get_instance())
         self.challenge.save()
         if self.challenge.WARRANTY:
             # give warranty back to initiator
@@ -612,7 +617,7 @@ class DefaultChallengeManager(ChallengeManager):
             result = (self.challenge.user_to, self.challenge.user_from)
         elif self.challenge.user_from.score > self.challenge.user_to.score:
             result = (self.challenge.user_from, self.challenge.user_to)
-        else: #draw game
+        else:  # draw game
             result = 'draw'
 
         return result
@@ -621,22 +626,22 @@ class DefaultChallengeManager(ChallengeManager):
         if self.challenge.status == 'D':
             action_msg = "chall-draw"
             signal_msg = ugettext_noop('draw result between {user_from} and {user_to}:\n{extra}')
-            signals.addActivity.send(sender=None, user_from=self.challenge.user_to.user, \
-                                     user_to=self.challenge.user_from.user, \
-                                     message=signal_msg, \
+            signals.addActivity.send(sender=None, user_from=self.challenge.user_to.user,
+                                     user_to=self.challenge.user_from.user,
+                                     message=signal_msg,
                                      arguments=dict(user_to=self.challenge.user_to, user_from=self.challenge.user_from,
-                                                    extra=self.challenge.extraInfo(self.challenge.user_from, self.challenge.user_to)),\
-                                     action=action_msg, \
+                                                    extra=self.challenge.extraInfo(self.challenge.user_from, self.challenge.user_to)),
+                                     action=action_msg,
                                      game=ChallengeGame.get_instance())
         elif self.challenge.status == 'P':
             action_msg = "chall-won"
             signal_msg = ugettext_noop('won challenge with {user_lost}: {extra}')
-            signals.addActivity.send(sender=None, user_from=self.challenge.user_won.user, \
-                                     user_to=self.challenge.user_lost.user, \
+            signals.addActivity.send(sender=None, user_from=self.challenge.user_won.user,
+                                     user_to=self.challenge.user_lost.user,
                                      message=signal_msg,
                                      arguments=dict(user_lost=self.challenge.user_lost, id=self.challenge.id,
-                                                    extra=self.challenge.extraInfo(self.challenge.user_won, self.challenge.user_lost)), \
-                                     action=action_msg, \
+                                                    extra=self.challenge.extraInfo(self.challenge.user_won, self.challenge.user_lost)),
+                                     action=action_msg,
                                      game=ChallengeGame.get_instance())
 
     def score(self):
@@ -677,18 +682,17 @@ class DefaultChallengeManager(ChallengeManager):
                           external_id=self.challenge.id, percents=self.challenge.user_won.percents,
                           points=self.challenge.user_won.score, points2=self.challenge.user_lost.score,
                           different_race=diff_race, different_class=diff_class,
-                          winner_points=winner_points, loser_points=loser_points,
-            )
+                          winner_points=winner_points, loser_points=loser_points)
 
             # Check for frenzy on the losing player
             if self.challenge.user_lost.user.magic.has_modifier('challenge-affect-scoring'):
                 self.challenge.user_lost.percents += self.challenge.user_lost.user.magic.modifier_percents('challenge-affect-scoring') - 100
 
-            #Check for spell evade
+            # Check for spell evade
             if self.challenge.user_lost.user.magic.has_modifier('challenge-evade'):
                 random.seed()
                 if random.random() < 0.20:
-                    #He's lucky, no penalty, return warranty
+                    # He's lucky, no penalty, return warranty
                     scoring.score(self.challenge.user_lost.user, ChallengeGame, 'chall-warranty-return', external_id=self.challenge.id)
                     Message.send(sender=None, receiver=self.challenge.user_lost.user, subject="Challenge evaded", text="You have just evaded losing points in a challenge")
 
@@ -743,26 +747,23 @@ class ChallengeGame(Game):
         fs = []
         chall_game = kls.get_instance()
         fs.append(dict(name='chall-won', expression='points=6+{different_race}+{different_class}',
-            owner=chall_game.game,
-            description='Points earned when winning a challenge. Arguments: different_race (int 0,1), different_class (int 0,1)')
-        )
+                       owner=chall_game.game,
+                       description='Points earned when winning a challenge. Arguments: different_race (int 0,1), different_class (int 0,1)'))
         fs.append(dict(name='chall-lost', expression='points=2',
-            owner=chall_game.game,
-            description='Points earned when losing a challenge')
-        )
+                       owner=chall_game.game,
+                       description='Points earned when losing a challenge'))
         fs.append(dict(name='chall-draw', expression='points=4',
-            owner=chall_game.game,
-            description='Points earned when drawing a challenge')
-        )
+                       owner=chall_game.game,
+                       description='Points earned when drawing a challenge'))
         fs.append(dict(name='chall-warranty', expression='points=-3',
-            owner=chall_game.game,
-            description='Points taken as a warranty for challenge'))
+                       owner=chall_game.game,
+                       description='Points taken as a warranty for challenge'))
         fs.append(dict(name='chall-warranty-return', expression='points=3',
-            owner=chall_game.game,
-            description='Points given back as a warranty taken for challenge'))
+                       owner=chall_game.game,
+                       description='Points given back as a warranty taken for challenge'))
         fs.append(dict(name='chall-timer',
-            expression='tlimit=300 - 5 * ({level} - 1)', owner=chall_game.game,
-            description='Seconds left for a user in challenge'))
+                       expression='tlimit=300 - 5 * ({level} - 1)', owner=chall_game.game,
+                       description='Seconds left for a user in challenge'))
         return fs
 
     @classmethod
@@ -770,14 +771,14 @@ class ChallengeGame(Game):
         """
         Challenge game modifiers
         """
-        return ['challenge-one-more', # challenge twice a day, positive
-                'challenge-cannot-be-challenged', # reject incoming challenges, negative
-                'challenge-cannot-challenge', # reject outgoing challenges, negative
-                'challenge-always-lose', # lose regardless the result, negative
-                'challenge-affect-scoring', # affect scoring by positive/negative percent
-                'challenge-affect-scoring-won', #affect scoring by positive/negative percent for win challenges
-                'challenge-evade', #33% chance player does not lose points in a challenge
-        ]
+        return ['challenge-one-more',  # challenge twice a day, positive
+                'challenge-cannot-be-challenged',  # reject incoming challenges, negative
+                'challenge-cannot-challenge',  # reject outgoing challenges, negative
+                'challenge-always-lose',  # lose regardless the result, negative
+                'challenge-affect-scoring',  # affect scoring by positive/negative percent
+                'challenge-affect-scoring-won',  # affect scoring by positive/negative percent for win challenges
+                'challenge-evade',  # 33% chance player does not lose points in a challenge
+                ]
 
     @classmethod
     def management_task(cls, now=None, stdout=sys.stdout):
@@ -802,11 +803,12 @@ class ChallengeGame(Game):
                 r'^challenge/launch/(?P<player_id>\d+)/$': ChallengeLaunch,
                 r'^challenge/(?P<challenge_id>\d+)/$': ChallengeHandler,
                 r'^challenge/(?P<challenge_id>\d+)/(?P<action>refuse|cancel|accept)/$': ChallengeHandler,
-        }
+                }
 
     @classmethod
     def get_manager(cls, challenge):
         return DefaultChallengeManager(challenge)
+
 
 # Hack for having participants in sync
 def challenge_post_delete(sender, instance, **kwargs):
@@ -816,5 +818,6 @@ def challenge_post_delete(sender, instance, **kwargs):
     try:
         instance.user_from.delete()
         instance.user_to.delete()
-    except: pass
+    except:
+        pass
 models.signals.post_delete.connect(challenge_post_delete, Challenge)

--- a/wouso/games/challenge/templates/challenge/statistics.html
+++ b/wouso/games/challenge/templates/challenge/statistics.html
@@ -11,9 +11,10 @@
 <p> {% trans 'Challenges sent: ' %} {{ n_chall_sent }}</p>
 <p> {% trans 'Challenges received: ' %} {{ n_chall_rec }}</p>
 <p> {% trans 'Challenges refused: ' %} {{ n_chall_ref }}</p>
-<p> {% trans 'Win percentage: ' %} {{ win_percentage }}%</p>
+<p> {% trans 'Win percentage: ' %} {{ win_percentage|floatformat:"-2" }}%</p>
 <p> {% trans 'Average time taken: ' %} {{ average_time }} {% trans 's' %} </p>
 <p> {% trans 'Average score: ' %} {{ average_score }} </p>
+<p><i> {% trans 'Note: 1 draw counts as 1/2 win and 1/2 loss when calculating win percentage.' %} </i></p>
 <table>
     <tr align=center>
         <td><b>Opponent</b></td>

--- a/wouso/interface/top/models.py
+++ b/wouso/interface/top/models.py
@@ -65,11 +65,12 @@ class TopUser(ObjectHistory, Player):
         return self.get_extension(ChallengeUser).get_lost_challenges().count()
 
     @property
-    def won_perc_challenges(self):
-        n = self.played_challenges
-        if n == 0:
-            return 0
-        return float(self.won_challenges) / n * 100.0
+    def draw_challenges(self):
+        return self.get_extension(ChallengeUser).get_draw_challenges().count()
+
+    @property
+    def win_percentage(self):
+        return self.get_extension(ChallengeUser).get_win_percentage()
 
     @property
     def weeklyprogress(self):
@@ -235,7 +236,7 @@ class History(models.Model): # TODO: deprecate (maybe), check if NewHistory cove
 
 
 class Top(App):
-       
+
     @classmethod
     def get_sidebar_widget(kls, context):
         if kls.disabled():

--- a/wouso/interface/top/models.py
+++ b/wouso/interface/top/models.py
@@ -36,7 +36,7 @@ class GroupHistory(ObjectHistory):
         """ :return: list of pairs (index, position) for the last week """
         hs = History.objects.filter(group=self.group, relative_to=relative_to).order_by('-date')[:7]
         tot = len(hs)
-        return [(tot - i, h.position) for (i,h) in enumerate(hs)]
+        return [(tot - i, h.position) for (i, h) in enumerate(hs)]
 
 
 class TopUser(ObjectHistory, Player):
@@ -76,7 +76,7 @@ class TopUser(ObjectHistory, Player):
     def weeklyprogress(self):
         hs = self.history()
         try:
-            yesterday     = hs[0]
+            yesterday = hs[0]
             day1weekprior = hs[-1]
         except Exception as e:
             logging.exception(e)
@@ -120,13 +120,13 @@ class TopUser(ObjectHistory, Player):
         else:
             hs = self.history().filter(relative_to=relative_to).order_by('-date')[:7]
         tot = len(hs)
-        return [(tot - i, h.position) for (i,h) in enumerate(hs)]
+        return [(tot - i, h.position) for (i, h) in enumerate(hs)]
 
     def week_points_evolution(self):
         """ :return: list of pairs (index, points) for the last week """
         hs = self.history()
         tot = len(hs)
-        return [(tot - i, h.points) for (i,h) in enumerate(hs)]
+        return [(tot - i, h.points) for (i, h) in enumerate(hs)]
 
 
 Player.register_extension('top', TopUser)
@@ -147,8 +147,11 @@ class NewHistory(models.Model):
     @classmethod
     def record(cls, obj, date, relative_to=None):
         relative_to_id = relative_to.id if relative_to else None
-        return cls.objects.get_or_create(object=obj.id, object_type=cls._get_type(obj), date=date,
-                                  relative_to=relative_to_id, relative_to_type=cls._get_type(relative_to))[0]
+        return cls.objects.get_or_create(object=obj.id,
+                                         object_type=cls._get_type(obj),
+                                         date=date,
+                                         relative_to=relative_to_id,
+                                         relative_to_type=cls._get_type(relative_to))[0]
 
     @classmethod
     def get_obj_position(cls, obj, relative_to=None):
@@ -164,9 +167,9 @@ class NewHistory(models.Model):
     @classmethod
     def get_children_top(cls, obj, type):
         date = datetime.today().date()
-        return type.objects.filter(id__in=cls.objects.filter(object_type=cls._get_type(type), date=date, relative_to=obj.id,
-                                                      relative_to_type=cls._get_type(obj)).order_by('position').values_list('object')
-        )
+        return type.objects.filter(id__in=cls.objects.filter(object_type=cls._get_type(type),
+                                   date=date, relative_to=obj.id,
+                                   relative_to_type=cls._get_type(obj)).order_by('position').values_list('object'))
 
     @classmethod
     def get_user_position(cls, player, relative_to=None):
@@ -203,7 +206,7 @@ class NewHistory(models.Model):
         return None
 
 
-class History(models.Model): # TODO: deprecate (maybe), check if NewHistory covers usage
+class History(models.Model):  # TODO: deprecate (maybe), check if NewHistory covers usage
     user = models.ForeignKey('TopUser', blank=True, null=True)
     group = models.ForeignKey(PlayerGroup, blank=True, null=True)
     relative_to = models.ForeignKey(PlayerGroup, blank=True, null=True, related_name='relativeto')
@@ -214,7 +217,7 @@ class History(models.Model): # TODO: deprecate (maybe), check if NewHistory cove
     @classmethod
     def get_user_position(kls, user, relative_to=None):
         try:
-            history = History.objects.filter(user=user,relative_to=relative_to).order_by('-date')[0]
+            history = History.objects.filter(user=user, relative_to=relative_to).order_by('-date')[0]
             return history.position
         except IndexError:
             return 0
@@ -232,7 +235,7 @@ class History(models.Model): # TODO: deprecate (maybe), check if NewHistory cove
             return 0
 
     def __unicode__(self):
-        return u"%s %s at %s, position: %d, points: %f" % ('[%s]' % self.relative_to if self.relative_to else '',self.user if self.user else self.group, self.date, self.position, self.points)
+        return u"%s %s at %s, position: %d, points: %f" % ('[%s]' % self.relative_to if self.relative_to else '', self.user if self.user else self.group, self.date, self.position, self.points)
 
 
 class Top(App):
@@ -244,17 +247,16 @@ class Top(App):
 
         top5 = TopUser.objects.exclude(user__is_superuser=True).exclude(race__can_play=False)
         top5 = top5.order_by('-points')[:10]
-        #is_top = request.get_full_path().startswith('/top/')
+        # is_top = request.get_full_path().startswith('/top/')
         is_top = context.get('top', False)
 
         return render_to_string('top/sidebar.html',
-            {'topusers': top5,
-             'is_top': is_top,
-             'top': Top,
-             'coin_top_setting': kls.coin_top_settings(),
-             'config_disable_challenge_top': BoolSetting.get('disable-Challenge-Top').get_value(),
-            }
-        )
+                                {'topusers': top5,
+                                 'is_top': is_top,
+                                 'top': Top,
+                                 'coin_top_setting': kls.coin_top_settings(),
+                                 'config_disable_challenge_top': BoolSetting.get('disable-Challenge-Top').get_value()
+                                })
 
     @classmethod
     def management_task(cls, now=None, stdout=sys.stdout):
@@ -263,7 +265,7 @@ class Top(App):
 
         # Global ladder
         stdout.write(' Updating players...\n')
-        for i,u in enumerate(Player.objects.all().order_by('-points')):
+        for i, u in enumerate(Player.objects.all().order_by('-points')):
             topuser = u.get_extension(TopUser)
             position = i + 1
             hs, new = History.objects.get_or_create(user=topuser, date=today, relative_to=None)
@@ -284,7 +286,7 @@ class Top(App):
         stdout.write(' Updating race history...\n')
         race_data = [(race, race.points) for race in Race.objects.all() if race.can_play]
         # sort by number of points, decreasing order
-        race_data = sorted(race_data, key=lambda r:r[1], reverse=True)
+        race_data = sorted(race_data, key=lambda r: r[1], reverse=True)
         for i, rd in enumerate(race_data):
             hs = NewHistory.record(rd[0], today, relative_to=None)
             hs.position, hs.points = i + 1, rd[1]
@@ -324,7 +326,7 @@ class Top(App):
 
         stdout.write(' Calculating coin %s top...' % coin)
         players = list(Player.objects.filter(race__can_play=True))
-        players.sort(lambda b,a: a.coins.get(coin) - b.coins.get(coin))
+        players.sort(lambda b, a: a.coins.get(coin) - b.coins.get(coin))
         for i, p in enumerate(players):
             hs = NewHistory.record(p, now, relative_to=coin_obj)
             hs.position, hs.points = i + 1, p.coins.get(coin_obj.name)
@@ -348,7 +350,7 @@ class Top(App):
 
 
 register_sidebar_block('top', Top.get_sidebar_widget)
-#def user_post_save(sender, instance, **kwargs):
+# def user_post_save(sender, instance, **kwargs):
 #    profile = instance.get_profile()
 #    profile.get_extension(TopUser)
-#models.signals.post_save.connect(user_post_save, User)
+# models.signals.post_save.connect(user_post_save, User)

--- a/wouso/interface/top/views.py
+++ b/wouso/interface/top/views.py
@@ -1,12 +1,12 @@
 # Create your views here.
 from wouso.core.scoring import Coin
-from wouso.core.user.models import  Race
+from wouso.core.user.models import Race
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.http import Http404
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
 from wouso.core.user.models import PlayerGroup
-from wouso.interface.top.models import  TopUser, Top, NewHistory
+from wouso.interface.top.models import TopUser, Top, NewHistory
 
 PERPAGE = 20
 TOPGROUPS_NO = 5
@@ -63,6 +63,7 @@ TOPGROUPS_NO = 5
 #                             'top': Top},
 #                            context_instance=RequestContext(request))
 
+
 def pyramid(request):
     s = []
     for r in Race.objects.exclude(can_play=False).order_by('name'):
@@ -79,8 +80,9 @@ def pyramid(request):
         s.append(r)
 
     return render_to_response('top/pyramid.html',
-                            {'series': s, 'top': Top},
-                            context_instance=RequestContext(request))
+                              {'series': s, 'top': Top},
+                              context_instance=RequestContext(request))
+
 
 def topclasses(request):
     # top classes
@@ -98,20 +100,24 @@ def topclasses(request):
     # append cannotplay_classes to classes
     classes.extend(cannotplay_classes)
 
-    return render_to_response('top/classes.html', {'classes':classes, 'top':Top},
+    return render_to_response('top/classes.html',
+                              {'classes': classes, 'top': Top},
                               context_instance=RequestContext(request))
+
 
 def topraces(request):
     # top races
     races = list(Race.objects.exclude(can_play=False))
     races.sort(key=lambda a: a.points, reverse=True)
-    return render_to_response('top/races.html', {'races':races, 'top':Top},
-                                context_instance=RequestContext(request))
+    return render_to_response('top/races.html',
+                              {'races': races, 'top': Top},
+                              context_instance=RequestContext(request))
+
 
 def challenge_top(request, sortcritno='0', pageno=1):
-    #sortcrit = 0 descending order of wins
-    #sortcrit = 1 descending order of % wins
-    #sortcrit = 2 descending order of losses
+    # sortcrit = 0 descending order of wins
+    # sortcrit = 1 descending order of % wins
+    # sortcrit = 2 descending order of losses
     base_query = TopUser.objects.exclude(user__is_superuser=True).exclude(race__can_play=False)
 
     if sortcritno == '0':
@@ -122,7 +128,6 @@ def challenge_top(request, sortcritno='0', pageno=1):
         allUsers = sorted(base_query, key=lambda x: -x.lost_challenges)
     else:
         allUsers = sorted(base_query, key=lambda x: -x.draw_challenges)
-
 
     paginator = Paginator(allUsers, PERPAGE)
     try:
@@ -140,14 +145,16 @@ def challenge_top(request, sortcritno='0', pageno=1):
     topgroups.sort(key=lambda obj: obj.live_points, reverse=True)
     topgroups = topgroups[:TOPGROUPS_NO]
 
-    return render_to_response('top/challenge_top.html', {
-                    'allUsers': users,
-                    'sortcritno': sortcritno,
-                    'topgroups': topgroups,
-                    'topseries': topseries,
-                    'is_top': True,
-                    'top': Top
-                    }, context_instance=RequestContext(request))
+    return render_to_response('top/challenge_top.html',
+                              {'allUsers': users,
+                               'sortcritno': sortcritno,
+                               'topgroups': topgroups,
+                               'topseries': topseries,
+                               'is_top': True,
+                               'top': Top
+                               },
+                              context_instance=RequestContext(request))
+
 
 def topcoin(request, coin):
     coin_obj = Coin.get(coin)
@@ -164,8 +171,6 @@ def topcoin(request, coin):
         pageno = 1
         topcoin = paginator.page(pageno)
 
-
     return render_to_response('top/coin_top.html',
-                {'top': topcoin, 'coin': coin_obj, 'page_start': (pageno - 1)* PERPAGE},
-                context_instance=RequestContext(request)
-    )
+                              {'top': topcoin, 'coin': coin_obj, 'page_start': (pageno - 1) * PERPAGE},
+                              context_instance=RequestContext(request))

--- a/wouso/interface/top/views.py
+++ b/wouso/interface/top/views.py
@@ -117,9 +117,12 @@ def challenge_top(request, sortcritno='0', pageno=1):
     if sortcritno == '0':
         allUsers = sorted(base_query, key=lambda x: -x.won_challenges)
     elif sortcritno == '1':
-        allUsers = sorted(base_query, key=lambda x: -x.won_perc_challenges)
-    else :
+        allUsers = sorted(base_query, key=lambda x: -x.win_percentage)
+    elif sortcritno == '2':
         allUsers = sorted(base_query, key=lambda x: -x.lost_challenges)
+    else:
+        allUsers = sorted(base_query, key=lambda x: -x.draw_challenges)
+
 
     paginator = Paginator(allUsers, PERPAGE)
     try:

--- a/wouso/resources/templates/top/challenge_top.html
+++ b/wouso/resources/templates/top/challenge_top.html
@@ -22,8 +22,9 @@
         <th>&nbsp;</th>
         <th width = "100%" align=left>{% trans 'Player' %}</th>
         <th> <a href="{% url challenge_top %}0/1/">{% trans 'Won' %}</a> </th>
-        <th nowrap> <a href="{% url challenge_top %}1/1/">{% trans 'Won %' %}</a> </th>
         <th> <a href="{% url challenge_top %}2/1/">{% trans 'Lost' %}</a> </th>
+        <th> <a href="{% url challenge_top %}3/1/">{% trans 'Draw' %}</a> </th>
+        <th nowrap> <a href="{% url challenge_top %}1/1/">{% trans 'Won %' %}</a> </th>
         <th nowrap> {% trans 'Last seen' %} </th>
     </tr>
 
@@ -38,8 +39,9 @@
         {% endfor %}
         </td>
         <td> {{ user.won_challenges }} </td>
-        <td> {{ user.won_perc_challenges|floatformat:"-2" }}%</td>
         <td> {{ user.lost_challenges }} </td>
+        <td> {{ user.draw_challenges }} </td>
+        <td> {{ user.win_percentage|floatformat:"-2" }}%</td>
         <td nowrap> {% if user.last_seen %}{{ user.last_seen }}{% else %}{% trans 'Never' %}{% endif %} </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
The current *winning percentage* is computed in two different pieces of code, one for *challenge top*, another for *challenge statistics*. Also, the formula used may seem not only misleading, but also incorrect as it takes into account the refused challenges too: 
```
win_percentage = wins / (wins + losses + draws + refuses)
```

Therefore, I'm proposing a few changes for *challenge top* and *challenge statistics*:
- use same method for computing *winning percentage* both for top and statistics;
- add **Draw** column in challenge top;
- use [this](https://en.wikipedia.org/wiki/Winning_percentage) formula for computing *win percentage*: 
```
win_percentage = (wins + draws/2) / (wins + losses + draws)
```