### PR TITLE
install.sh: Add support for Fedora systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ World of USO is a quiz game framework. It has been used since 2007 as a support 
 
 ## Easy install
 
-On a Debian-based system run the install script:
+On a Mint/Ubuntu/Fedora system run the install script:
 
     ./install.sh
 
-If everything installs succesfully go to step 9 to start the server.
+During the installation you will be asked to enter an username and password for the administrative user. You will use those to do the first login into World of USO and use full privileges for administrative actions.
+
+If everything installs successfully go to step 9 to start the server.
 
 ## Requirements
 
@@ -39,9 +41,10 @@ On a **Fedora 21 or lower** system run the command:
 
     sudo yum -y install python-pip python-django python-devel python-virtualenv openldap-devel libgsasl-devel openssl-devel
 
-In case of MySQL support:
-
-    sudo apt-get install mysql-server mysql-client libmysqlclient-dev
+Optional packages (in case of MySQL support):
+* mysql-server
+* mysql-client
+* libmysqlclient-dev
 
 
 ## Installing WoUSO
@@ -118,7 +121,7 @@ In case of MySQL support:
 
         ./manage.py wousoctl --setup
 
-    You will be requested for an username and password for the administrative user. You will use those to first login into World of USO and use full priviliges for administrative actions.
+    You will be asked to enter an username and password for the administrative user. You will use those to do the first login into World of USO and use full privileges for administrative actions.
 
 9. Run the server:
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,28 @@
 #!/bin/bash
 
-# Install operating system dependencies
-sudo apt-get install python2.7 python-pip python-django python-dev python-virtualenv libldap2-dev libsasl2-dev libssl-dev
+# Retrieve distribution and release version
+DISTRIBUTION=$(lsb_release -i 2> /dev/null | cut -d ':' -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+RELEASE=$(lsb_release -r 2> /dev/null | cut -d ':' -f 2 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+ERR_MSG="Unsupported Linux distribution, please install manually.
+See https://github.com/rosedu/wouso#installing-wouso for details.
+Aborting..."
+
+if [ -z "$DISTRIBUTION" -o -z "$RELEASE" ]; then
+    echo -e "$ERR_MSG"; exit 1
+fi
+
+# Install dependencies
+if [ "$DISTRIBUTION" == "Ubuntu" -o "$DISTRIBUTION" == "LinuxMint" ]; then
+    sudo apt-get install python2.7 python-pip python-django python-dev python-virtualenv libldap2-dev libsasl2-dev libssl-dev
+elif [ "$DISTRIBUTION" == "Fedora" ]; then
+    if [ "$RELEASE" -ge 22 ]; then
+        sudo dnf -y install python-pip python-django python-devel python-virtualenv openldap-devel libgsasl-devel openssl-devel
+    else
+        sudo yum -y install python-pip python-django python-devel python-virtualenv openldap-devel libgsasl-devel openssl-devel
+    fi
+else
+    echo -e "$ERR_MSG"; exit 1
+fi
 
 # Enter the sandbox
 virtualenv -p python2.7 sandbox


### PR DESCRIPTION
This allows the `install.sh` script to work on LinuxMint/Ubuntu/Fedora systems.

We'll have to look for another way to have a more generic support (i.e. for all Debian/RedHat distributions) in the future.
