### PR TITLE
Add option to disable site's Mobile Version

### DIFF
--- a/wouso/interface/cpanel/models.py
+++ b/wouso/interface/cpanel/models.py
@@ -41,7 +41,7 @@ class Switchboard(ConfigGroup):
         p = []
         for a in ('Qproposal', 'Top', 'Magic', 'Bazaar', 'Bazaar-Exchange',
                   'Statistics', 'Challenge-Top', 'Top-Pyramid', 'Lesson',
-                  'MessageApp', 'File'):
+                  'MessageApp', 'File', 'Mobile-Version'):
             p.append(BoolSetting.get('disable-%s' % a))
 
         staff_only_login = BoolSetting.get('staff-only-login')

--- a/wouso/interface/views.py
+++ b/wouso/interface/views.py
@@ -15,6 +15,7 @@ from django.template import RequestContext
 from django.views.decorators.csrf import csrf_exempt
 
 from wouso.core import signals
+from wouso.core.config.models import BoolSetting
 from wouso.interface import logger, detect_mobile
 from wouso.interface.apps.pages.models import NewsItem
 from wouso.core.game import get_games
@@ -121,7 +122,7 @@ def homepage(request, page=u'1'):
     for g in topgroups:
         g.position = TopHistory.get_user_position(topuser, relative_to=g)
 
-    if detect_mobile(request):
+    if detect_mobile(request) and BoolSetting.get('disable-Mobile-Version').get_value() is False:
         template = 'mobile_index.html'
     else:
         template = 'site_index.html'


### PR DESCRIPTION
The way customization options work is really complicated. I've opened an issue here #891 so we can better focus our efforts on the customization model's refactoring.

The site's mobile version has not been looked at in a long time. Currently, disabling some features and games from the control panel has no effect on options displayed on the mobile home page #892. Until [892] is fixed, just add an option to disable the mobile version. I messed up things too many times because of that so someone should have a look before I push this (@gabrielivascu).
