### PR TITLE
Validate add/edit question forms

### DIFF
--- a/wouso/interface/cpanel/forms.py
+++ b/wouso/interface/cpanel/forms.py
@@ -48,6 +48,34 @@ class AddQuestionForm(forms.Form):
 
         self.instance = instance
 
+    def clean(self):
+        data = self.cleaned_data
+        num = IntegerSetting.get('question_number_of_answers').get_value()
+
+        # Check the question text. If the normal text is missing, check for the
+        # rich text. If that is missing too, something is wrong. Also, don't
+        # allow any empty active answers.
+        if 'text' in data and data['text'].strip() == '':
+            if 'rich_text' not in data or data['rich_text'].strip() == '':
+                raise forms.ValidationError("Invalid question text")
+            else:
+                for i in xrange(1, num + 1):
+                    if data['rich_active_%d' % i] is True and \
+                       data['rich_answer_%d' % i].strip() == '':
+                            raise forms.ValidationError("Empty active answer")
+        else:
+            for i in xrange(1, num + 1):
+                if data['active_%d' % i] is True and \
+                   data['answer_%d' % i].strip() == '':
+                        raise forms.ValidationError("Empty active answer")
+
+        # In case of QotD, check for a valid schedule.
+        if 'category' in data and data['category'] == 'qotd':
+            if 'schedule' not in data or data['schedule'] is None:
+                raise forms.ValidationError("Invalid schedule")
+
+        return self.cleaned_data
+
     def save(self):
         data = self.cleaned_data
 
@@ -141,6 +169,34 @@ class EditQuestionForm(forms.Form):
         self.fields['rich_text'] = forms.CharField(required=False, widget=CKEditorWidget(), initial=instance.rich_text)
 
         self.instance = instance
+
+    def clean(self):
+        data = self.cleaned_data
+        num = IntegerSetting.get('question_number_of_answers').get_value()
+
+        # Check the question text. If the normal text is missing, check for the
+        # rich text. If that is missing too, something is wrong. Also, don't
+        # allow any empty active answers.
+        if 'text' in data and data['text'].strip() == '':
+            if 'rich_text' not in data or data['rich_text'].strip() == '':
+                raise forms.ValidationError("Invalid question text")
+            else:
+                for i in xrange(1, num + 1):
+                    if data['rich_active_%d' % i] is True and \
+                       data['rich_answer_%d' % i].strip() == '':
+                            raise forms.ValidationError("Empty active answer")
+        else:
+            for i in xrange(1, num + 1):
+                if data['active_%d' % i] is True and \
+                   data['answer_%d' % i].strip() == '':
+                        raise forms.ValidationError("Empty active answer")
+
+        # In case of QotD, check for a valid schedule.
+        if 'category' in data and data['category'] == 'qotd':
+            if 'schedule' not in data or data['schedule'] is None:
+                raise forms.ValidationError("Invalid schedule")
+
+        return self.cleaned_data
 
     def save(self):
         data = self.cleaned_data

--- a/wouso/resources/templates/cpanel/add_question.html
+++ b/wouso/resources/templates/cpanel/add_question.html
@@ -52,6 +52,12 @@
 {% endblock %}
 
 {% block subsectioncontent %}
+    <div style="color: red;">
+        {% if form.errors %}
+            {{ form.errors }}
+        {% endif %}
+    </div>
+
     <form class="form-horizontal" method="post">
         <div class="form-group">
             <label for="text_type" class="control-label col-sm-3">Select question text type</label>

--- a/wouso/resources/templates/cpanel/edit_question.html
+++ b/wouso/resources/templates/cpanel/edit_question.html
@@ -33,7 +33,12 @@
 
 {% block sectioncontent %}
     <form class="form-horizontal" method="post">
-        {{ form.errors }}
+        <div style="color: red;">
+            {% if form.errors %}
+                {{ form.errors }}
+            {% endif %}
+        </div>
+
         <p class="formfield">
             <label>Proposed by</label>
             {{ question.proposed_by }}


### PR DESCRIPTION
It has been reported that users can answer questions in Quest by leaving the answer field empty or filling it with whitespaces. This was happening because the questions had one or more empty answers marked as active, causing `return answer.strip().lower() in [a.__unicode__().lower() for a in question.answers]` to return `True` when checking for a correct answer.

In order to avoid this problem in the future, validate the add/edit question forms by not allowing any empty active answers. Also, check for empty question texts and invalid schedules in case of questions in the QotD category.

P.S. I'm not happy with the duplicate code in `interface/cpanel/forms.py` either.

Ping @iulianR
